### PR TITLE
Fix desktop file rewriting

### DIFF
--- a/page.codeberg.dnkl.foot.yml
+++ b/page.codeberg.dnkl.foot.yml
@@ -73,7 +73,7 @@ modules:
     config-opts:
       - -Dterminfo=disabled
     post-install:
-      - desktop-file-edit --set-key="Exec" --set-value="foot-wrapper.sh" "../foot.desktop"
+      - desktop-file-edit --set-key="Exec" --set-value="foot-wrapper.sh" "/app/share/applications/foot.desktop"
       - install -Dm755 ../foot-wrapper.sh -t /app/bin/
       - install -Dm644 ../page.codeberg.dnkl.foot.metainfo.xml -t /app/share/metainfo/
     sources:


### PR DESCRIPTION
When switching from `build-commands` to `post-install` during the review process the desktop file exec rewriting process began editing the source repo desktop file after it was already installed. This would mean that the actual desktop file in the Flatpak would not get rewritten. This change edits the installed desktop file instead of the source file.